### PR TITLE
Non-participating discord members have their name updated too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 niceData/*
 
 .secret
+
+__pycache__

--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,8 @@ from discord.ext import commands
 
 from dataclasses import Scoreboard
 
+import utils
+
 bot = commands.Bot(command_prefix = '.')
 
 @bot.event
@@ -25,6 +27,7 @@ async def on_message(msg):
 		return
 
 	scoreboard = Scoreboard(guild.id)
+	await scoreboard.updateUsernames()
 	reply = scoreboard.nice(user.id, user.display_name)
 
 	print('>>>> ---- <<<< ---- >>>> ---- <<<<\n')
@@ -37,4 +40,5 @@ async def on_message(msg):
 with open('.secret', 'r') as f:
 	secret = f.read()
 
+utils.init(bot)
 bot.run(secret)

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -15,11 +15,8 @@ class User:
 	def __str__(self):
 		return f'{self.id} + {self.name} + {self.count}'
 
-	def nice(self, name = ''):
+	def nice(self):
 		self.count += 1
-
-		if name != '' and False:
-			self.name = name
 
 	async def updateName(self, gid):
 		name = await fetchUserName(self.id, gid)
@@ -43,7 +40,7 @@ class Scoreboard:
 		i = -1
 		try:
 			i = [ x.id for x in self.board ].index(id)
-			self.board[i].nice(name)
+			self.board[i].nice()
 			while i > 0 and self.board[i].count > self.board[i-1].count:
 				self.board[i], self.board[i-1] = self.board[i-1], self.board[i]
 				i -= 1

--- a/dataclasses.py
+++ b/dataclasses.py
@@ -3,6 +3,8 @@ import pickle
 
 from pathlib import Path
 
+from utils import fetchUserName
+
 class User:
 
 	def __init__(self, id, name):
@@ -16,7 +18,12 @@ class User:
 	def nice(self, name = ''):
 		self.count += 1
 
-		if name != '':
+		if name != '' and False:
+			self.name = name
+
+	async def updateName(self, gid):
+		name = await fetchUserName(self.id, gid)
+		if name != None:
 			self.name = name
 
 class Scoreboard:
@@ -53,6 +60,10 @@ class Scoreboard:
 		pickle.dump(self.board, open(f'niceData/{self.gid}.bin', 'wb'))
 
 		return self.getLeaderboard(i)
+
+	async def updateUsernames(self):
+		for user in self.board:
+			await user.updateName(self.gid)
 
 	def getLeaderboard(self, i):
 		ret = '𝓷𝓲𝓬𝓮 ☜(ﾟヮﾟ☜)\n\nNice Leaderboard\n'

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,17 @@
+
+from discord.utils import get
+
+botReference = None
+
+def init(bot):
+    global botReference
+    botReference = bot
+
+async def fetchUserName(id, gid):
+    guild = await botReference.fetch_guild(gid)
+    member = await guild.fetch_member(id)
+    if member == None or member.nick == None:
+        user = await botReference.fetch_user(id)
+        return None if user == None else user.name
+    else:
+        return member.nick

--- a/utils.py
+++ b/utils.py
@@ -8,10 +8,18 @@ def init(bot):
     botReference = bot
 
 async def fetchUserName(id, gid):
-    guild = await botReference.fetch_guild(gid)
-    member = await guild.fetch_member(id)
-    if member == None or member.nick == None:
-        user = await botReference.fetch_user(id)
-        return None if user == None else user.name
+    fetch_failed = False
+    try:
+        guild = await botReference.fetch_guild(gid)
+        member = await guild.fetch_member(id)
+    except:
+        fetch_failed = True
+    if fetch_failed or member == None or member.nick == None:
+        fetch_failed = False
+        try:
+            user = await botReference.fetch_user(id)
+        except:
+            fetch_failed = True
+        return None if fetch_failed or user == None else user.name
     else:
         return member.nick


### PR DESCRIPTION
Previously nicknames were only updated if the user posted a `nice`.
Now when a `nice` happens a fetch is run to get the names of the other users to update the board and if they last a fetch using `get_user` is ran to get their discord username, even if they change it.