### PR TITLE
Changing discord.py to pycord

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-async-timeout==3.0.1
-discord.py==1.3.4
+async-timeout==4.0.2
+py-cord==2.4.0


### PR DESCRIPTION
Since discord.py has been sunsetted the package became more unstable requiring unavailable dependencies and not supporting new features. This PR will change it to a fork of the same package called pycord, while maintaining all the current features. 